### PR TITLE
fix: use header-based DeepL auth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "deepl-translate",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.0.1",
+      "name": "deepl-translate",
+      "version": "0.0.2",
       "dependencies": {
         "axios": "0.21.4",
         "comment-translate-manager": "^0.0.2",

--- a/src/deepLTranslate.ts
+++ b/src/deepLTranslate.ts
@@ -78,12 +78,16 @@ export class DeepLTranslate implements ITranslate {
         const data = {
             text: content,
             'target_lang': convertLang(to),
-            'auth_key': this._defaultOption.authKey,
             'preserve_formatting': this._defaultOption.preserveFormatting,
             formality: this._defaultOption.formality
         };
 
-        let res = await axios.post<Response>(url,querystring.stringify(data));
+        const headers = {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'Authorization': `DeepL-Auth-Key ${this._defaultOption.authKey}`,
+        };
+
+        let res = await axios.post<Response>(url, querystring.stringify(data), { headers });
 
         return res.data.translations[0].text;
     }
@@ -98,7 +102,6 @@ export class DeepLTranslate implements ITranslate {
         return true;
     }
 }
-
 
 
 


### PR DESCRIPTION
## Summary
- Use header-based DeepL authentication (Authorization: DeepL-Auth-Key)
- Remove legacy body auth_key param
- Keep urlencoded request body

## Why
DeepL deprecated legacy form-body auth; requests now require header-based authentication, otherwise 403 is returned.

## Test
- npm run -s compile